### PR TITLE
Replace "xrange" with "range" for Python3 compatibility.

### DIFF
--- a/xtensa.py
+++ b/xtensa.py
@@ -375,7 +375,7 @@ class XtensaProcessor(processor_t):
 			instr.id = i
 
 	def _init_registers(self):
-		self.regNames = ["a%d" % d for d in xrange(16)]
+		self.regNames = ["a%d" % d for d in range(16)]
 		self.regNames += ["pc", "sar", "CS", "DS"]
 		self.reg_ids = {}
 		for i, reg in enumerate(self.regNames):
@@ -413,7 +413,7 @@ class XtensaProcessor(processor_t):
 		
 		self.cmd.itype = instr.id
 
-		operands = [self.cmd[i] for i in xrange(6)]
+		operands = [self.cmd[i] for i in range(6)]
 		for o in operands:
 			o.type = o_void
 		instr.parseOperands(operands, op, self.cmd)
@@ -421,7 +421,7 @@ class XtensaProcessor(processor_t):
 		return self.cmd.size
 
 	def emu(self):
-		for i in xrange(6):
+		for i in range(6):
 			op = self.cmd[i]
 			if op.type == o_void:
 				break
@@ -463,7 +463,7 @@ class XtensaProcessor(processor_t):
 
 		instr = self.instrs_list[self.cmd.itype]
 
-		for i in xrange(6):
+		for i in range(6):
 			if self.cmd[i].type == o_void:
 				break
 


### PR DESCRIPTION
As required by ScratchABit interactive disassembler,
https://github.com/pfalcon/ScratchABit . Yes, this means that when run on
Python2, there will be lists created instead of ranges, but they are small,
so the change has negligible effect on Python2, and it's the cleanest way
to achieve cross-Python compatibility.